### PR TITLE
🐛 修复因引入 tsx 带拓展名爆红

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import { createRoot } from 'react-dom/client'
 import { GlobalStyle } from './_html/style'
 //[ style ]
 
-import App from './App.tsx'
+import App from './App'
 //[ APP ]
 
 //=> Render | 渲染页面


### PR DESCRIPTION
- 修复 `allowImportingTsExtensions` 开启时 `import *.tsx` 出现 `ts(5097)`